### PR TITLE
Optimize startup

### DIFF
--- a/src/client/tslint.json
+++ b/src/client/tslint.json
@@ -23,10 +23,6 @@
     ],
     "interface-over-type-literal": true,
     "label-position": true,
-    "max-line-length": [
-      true,
-      140
-    ],
     "member-access": false,
     "member-ordering": [
       true,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -8,16 +8,15 @@ import { FileLibrary } from './filelibrary';
 import { VLCOpener } from './vlcopener';
 import { Screenshotter } from './screenshotter';
 
-export function compose(libraryPath: string, configuration: LaputinConfiguration): Laputin {
+export function compose(
+    libraryPath: string,
+    configuration: LaputinConfiguration,
+    screenshotter: Screenshotter
+): Laputin {
     const library = new Library(libraryPath);
 
     const hasher: IHasher = composeHasher(configuration);
-    const fileLibrary = new FileLibrary(
-        library,
-        libraryPath,
-        hasher,
-        new Screenshotter(libraryPath)
-    );
+    const fileLibrary = new FileLibrary(library, libraryPath, hasher, screenshotter);
 
     const opener = new VLCOpener(libraryPath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {Laputin} from './laputin';
 import {Library} from './library';
 import {LaputinConfiguration} from './laputinconfiguration';
 import {compose} from './compose';
+import { Screenshotter } from './screenshotter';
 
 (async function() {
     const argumentDefinitions = [
@@ -62,7 +63,7 @@ import {compose} from './compose';
         ? JSON.parse(fs.readFileSync(configFilePath, 'utf8'))
         : new LaputinConfiguration(3200, 'accurate');
 
-    const laputin = compose(options.libraryPath, configuration);
+    const laputin = compose(options.libraryPath, configuration, new Screenshotter(options.libraryPath));
 
     laputin.initializeRoutes();
 

--- a/src/laputin.ts
+++ b/src/laputin.ts
@@ -60,7 +60,6 @@ export class Laputin {
     }
 
     public async loadFiles(): Promise<void> {
-        await this.library.deactivateAll();
         return this.fileLibrary.load();
     }
 

--- a/src/tests/apitests.ts
+++ b/src/tests/apitests.ts
@@ -265,7 +265,8 @@ describe('Laputin API', function () {
         rimraf.sync(archivePath);
         fs.mkdirSync(archivePath);
 
-        const l = compose(archivePath, new LaputinConfiguration(1234, 'accurate'));
+        const fakeScreenshotter: any = {exists: () => {}, screenshot: () => {}, screenshotTimecode: () => {}};
+        const l = compose(archivePath, new LaputinConfiguration(1234, 'accurate'), fakeScreenshotter);
         l.initializeRoutes();
 
         await l.library.createTables();

--- a/src/tests/hashertests.ts
+++ b/src/tests/hashertests.ts
@@ -10,7 +10,8 @@ import {QuickMD5Hasher} from './../quickmd5hasher';
 describe('Hasher tests', function() {
     it('SHA-512 hasher', async () => {
         const hasher = new Sha512Hasher();
-        const hash = await hasher.hash('tests/test-content/cats.jpg', {}, null);
+        const fakeStats: any = { size: 30791 };
+        const hash = await hasher.hash('tests/test-content/cats.jpg', {}, fakeStats);
 
         const expectedHash =
          '70342c64bed51a0921b68e2df2fe893bc52c89454ee2dcb47aff436b7259d71805dbaf36838db76a7e919ba6249273d261b0f892b8b4958748350ff1f25d572e';
@@ -19,7 +20,8 @@ describe('Hasher tests', function() {
 
     it('Quick MD5 hasher', async () => {
         const hasher = new QuickMD5Hasher();
-        const hash = await hasher.hash('tests/test-content/cats.jpg', {}, null);
+        const fakeStats: any = { size: 30791 };
+        const hash = await hasher.hash('tests/test-content/cats.jpg', {}, fakeStats);
 
         expect(hash).to.eql('ea411d1af31ebb729a37c58c8e34236c');
     });

--- a/src/tests/monitoringtests.ts
+++ b/src/tests/monitoringtests.ts
@@ -30,221 +30,345 @@ describe('File Library', function() {
         '44f332dadcd09cc73c14b30a8334c1bf7d615829dd111f47fa9d3ae212933e32cbf59cd700010bd0e950309d64c23b03badcb990170676e003a0b02b63d3e757';
 
     beforeEach(async function() {
-        currentPath = this.currentTest.title.toLowerCase().replace(/ /g, '_');
+        currentPath = this.currentTest.fullTitle().toLowerCase().replace(/ /g, '_');
     });
 
     afterEach(async () => {
-        if (laputin) {
-            laputin.fileLibrary.close();
-            await laputin.stopListening();
-        }
+        shutdownLaputin(laputin);
     });
 
-    it('No files can be found from empty directory', async () => {
-        laputin = await initializeLaputin(currentPath);
+    describe('Detecting initial state', () => {
+        it('No files can be found from empty directory', async () => {
+            laputin = await initializeLaputin(currentPath);
 
-        return shouldContainFiles(laputin, []);
-    });
-
-    it('When file is copied to library path, it can be found', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
-
-        // Start monitoring before file is copied
-        laputin = await initializeLaputin(currentPath);
-
-        await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
-        await waitForEvent(laputin.fileLibrary, 'found', 8000);
-        return shouldContainFiles(laputin, [carFile]);
-    });
-
-    it('When file is moved without changing its content, it can be found with same hash from new path', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/automobile.jpg', [], 39031);
-
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
-        await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
-
-        // Start monitoring before file is copied
-        laputin = await initializeLaputin(currentPath);
-
-        fs.renameSync('deploy-tests/' + currentPath + '/car.jpg', 'deploy-tests/' + currentPath + '/automobile.jpg');
-        await waitForEvent(laputin.fileLibrary, 'found', 8000);
-        return shouldContainFiles(laputin, [carFile]);
-    });
-
-    it('Initial files can be found', async () => {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
-        const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
-
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
-        await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
-        await copyFile('tests/test-content/cats.jpg', 'deploy-tests/' + currentPath + '/cats.jpg');
-        await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
-
-        // Start monitoring after files have been copied
-        laputin = await initializeLaputin(currentPath);
-
-        return shouldContainFiles(laputin, [carFile, catsFile, landscapeFile]);
-    });
-
-    it('When file is deleted from library path, it can no longer be found', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
-        const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
-
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
-        await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
-        await copyFile('tests/test-content/cats.jpg', 'deploy-tests/' + currentPath + '/cats.jpg');
-        await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
-
-        // Start monitoring after files have been copied
-        laputin = await initializeLaputin(currentPath);
-
-        fs.unlinkSync('deploy-tests/' + currentPath + '/cats.jpg');
-        await waitForEvent(laputin.fileLibrary, 'lost', 8000);
-        return await shouldContainFiles(laputin, [carFile, landscapeFile]);
-    });
-
-    it('When a duplicate file is copied to library path, it is detected as duplicate', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
-        const duplicateCarFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car-duplicate.jpg', [], 39031);
-
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
-        await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
-
-        // Start monitoring after files have been copied
-        laputin = await initializeLaputin(currentPath);
-
-        await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car-duplicate.jpg');
-        await waitForEvent(laputin.fileLibrary, 'found', 8000);
-
-        const duplicates = laputin.fileLibrary.getDuplicates();
-        expect(duplicates).to.eql({
-        '32f38f740bdeb0ca8fae735b9b149152181d6591303b80fb81cc6f189f3070d4f6b153c136ca8111c9e25c31f670e29983aef866c9055595d6e47764457b2592':
-            [carFile, duplicateCarFile]
+            return shouldContainFiles(laputin, []);
         });
 
-        // Note that Laputin returns newly copied duplicate version of car.
-        // This is because newer versions of file with same hash are always
-        // used to overwrite the previous path.
-        return await shouldContainFiles(laputin, [duplicateCarFile]);
+        it('Initial files can be found', async () => {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+            const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
+            const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
+            await copyFile('tests/test-content/cats.jpg', 'deploy-tests/' + currentPath + '/cats.jpg');
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+
+            // Start monitoring after files have been copied
+            laputin = await initializeLaputin(currentPath);
+
+            return shouldContainFiles(laputin, [carFile, catsFile, landscapeFile]);
+        });
     });
 
-    it('When a file is overwritten with exact same file to exact same path, it is not detected as duplicate', async function() {
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
+    describe('New file detected', () => {
+        it('Offline', async () => {
+            // Initial startup and shutdown
+            laputin = await initializeLaputin(currentPath);
+            shutdownLaputin(laputin);
 
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
-        await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
 
-        // Start monitoring after initial files have been copied
-        laputin = await initializeLaputin(currentPath);
+            // Detecting changes after second startup
+            await startLaputin(laputin);
 
-        await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
-        await waitForEvent(laputin.fileLibrary, 'found', 8000);
+            return shouldContainFiles(laputin, [carFile]);
+        });
 
-        const duplicates = laputin.fileLibrary.getDuplicates();
-        expect(duplicates).to.eql({});
+        it('Online', async function() {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
 
-        return await shouldContainFiles(laputin, [landscapeFile]);
+            // Start monitoring before file is copied
+            laputin = await initializeLaputin(currentPath);
+
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
+            await waitForEvent(laputin.fileLibrary, 'found', 8000);
+            return shouldContainFiles(laputin, [carFile]);
+        });
     });
 
-    it('When a file is renamed, it is not detected as duplicate', async function() {
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
+    describe('File path change detected', () => {
+        it('Offline', async () => {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/automobile.jpg', [], 39031);
 
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
-        await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
 
-        // Start monitoring after initial files have been copied
-        laputin = await initializeLaputin(currentPath);
+            // Initial startup and shutdown
+            laputin = await initializeLaputin(currentPath);
+            shutdownLaputin(laputin);
 
-        await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
-        await waitForEvent(laputin.fileLibrary, 'found', 8000);
+            fs.renameSync('deploy-tests/' + currentPath + '/car.jpg', 'deploy-tests/' + currentPath + '/automobile.jpg');
 
-        const duplicates = laputin.fileLibrary.getDuplicates();
-        expect(duplicates).to.eql({});
+            // Detecting changes after second startup
+            await startLaputin(laputin);
 
-        return await shouldContainFiles(laputin, [landscapeFile]);
+            return shouldContainFiles(laputin, [carFile]);
+        });
+
+        it('Online', async function() {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/automobile.jpg', [], 39031);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
+
+            // Start monitoring before file is copied
+            laputin = await initializeLaputin(currentPath);
+
+            fs.renameSync('deploy-tests/' + currentPath + '/car.jpg', 'deploy-tests/' + currentPath + '/automobile.jpg');
+            await waitForEvent(laputin.fileLibrary, 'found', 8000);
+            return shouldContainFiles(laputin, [carFile]);
+        });
     });
 
-    it('When a directory is created in library directory, it is not detected as a file', async function() {
-        fs.mkdirSync('deploy-tests/' + currentPath + '');
+    describe('File deletion detected', () => {
+        it('Offline', async function () {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+            const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
+            const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
 
-        laputin = await initializeLaputin(currentPath);
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
+            await copyFile('tests/test-content/cats.jpg', 'deploy-tests/' + currentPath + '/cats.jpg');
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
 
-        fs.mkdirSync('deploy-tests/' + currentPath + '/foobar');
-        await delay(1000);
+            // Initial startup and shutdown
+            laputin = await initializeLaputin(currentPath);
+            shutdownLaputin(laputin);
 
-        return await shouldContainFiles(laputin, []);
+            fs.unlinkSync('deploy-tests/' + currentPath + '/cats.jpg');
+
+            // Detecting changes after second startup
+            await startLaputin(laputin);
+
+            return await shouldContainFiles(laputin, [carFile, landscapeFile]);
+        });
+
+        it('Online', async function () {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+            const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
+            const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
+            await copyFile('tests/test-content/cats.jpg', 'deploy-tests/' + currentPath + '/cats.jpg');
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+
+            // Start monitoring after files have been copied
+            laputin = await initializeLaputin(currentPath);
+
+            fs.unlinkSync('deploy-tests/' + currentPath + '/cats.jpg');
+            await waitForEvent(laputin.fileLibrary, 'lost', 8000);
+            return await shouldContainFiles(laputin, [carFile, landscapeFile]);
+        });
     });
 
-    function shouldContainFiles(l: Laputin, expectedFiles: File[]): request.Test {
-        return request(l.app)
-            .get('/api/files')
-            .expect(200)
-            .expect(expectedFiles);
-    }
+    describe('Duplicate file detected', () => {
+        it('Offline', async function () {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+            const duplicateCarFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car-duplicate.jpg', [], 39031);
 
-    function shouldContainDuplicates(l: Laputin, expectedFiles: any): request.Test {
-        return request(l.app)
-            .get('/api/duplicates')
-            .expect(200)
-            .expect(expectedFiles);
-    }
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
 
-    function waitForEvent(emitter: events.EventEmitter, eventName: string, timeoutMs: number): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            const errTimeout = setTimeout(
-                () => reject(new Error('Event ' + eventName + ' was not emitted')),
-                timeoutMs);
+            // Initial startup and shutdown
+            laputin = await initializeLaputin(currentPath);
+            shutdownLaputin(laputin);
 
-            emitter.on(eventName, () => {
-                clearTimeout(errTimeout);
-                resolve();
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car-duplicate.jpg');
+
+            // Detecting changes after second startup
+            await startLaputin(laputin);
+
+            const duplicates = laputin.fileLibrary.getDuplicates();
+            expect(duplicates).to.eql({
+            '32f38f740bdeb0ca8fae735b9b149152181d6591303b80fb81cc6f189f3070d4f6b153c136ca8111c9e25c31f670e29983aef866c9055595d6e47764457b2592':
+                [carFile, duplicateCarFile]
             });
+
+            // Note that Laputin returns newly copied duplicate version of car.
+            // This is because newer versions of file with same hash are always
+            // used to overwrite the previous path.
+            return await shouldContainFiles(laputin, [duplicateCarFile]);
         });
-    }
 
-    async function initializeLaputin(path: string): Promise<Laputin> {
-        const archivePath = 'deploy-tests/' + path;
+        it('Online', async function () {
+            const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+            const duplicateCarFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car-duplicate.jpg', [], 39031);
 
-        if (!fs.existsSync(archivePath)) {
-            fs.mkdirSync(archivePath);
-        }
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
 
-        const fakeScreenshotter: any = {exists: () => {}, screenshot: () => {}, screenshotTimecode: () => {}};
-        const l = compose(archivePath, new LaputinConfiguration(1234, 'accurate'), fakeScreenshotter);
-        l.initializeRoutes();
-        await l.library.createTables();
-        await l.loadFiles();
+            // Start monitoring after files have been copied
+            laputin = await initializeLaputin(currentPath);
 
-        await l.startListening();
+            await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car-duplicate.jpg');
+            await waitForEvent(laputin.fileLibrary, 'found', 8000);
 
-        // File monitoring seems to need some time to wake up
-        await delay(100);
+            const duplicates = laputin.fileLibrary.getDuplicates();
+            expect(duplicates).to.eql({
+            '32f38f740bdeb0ca8fae735b9b149152181d6591303b80fb81cc6f189f3070d4f6b153c136ca8111c9e25c31f670e29983aef866c9055595d6e47764457b2592':
+                [carFile, duplicateCarFile]
+            });
 
-        return l;
-    }
-
-    function copyFile(source: string, target: string): Promise<void> {
-        return new Promise<void>(function(resolve, reject) {
-            const rd = fs.createReadStream(source);
-            rd.on('error', reject);
-            const wr = fs.createWriteStream(target);
-            wr.on('error', reject);
-            wr.on('finish', resolve);
-            rd.pipe(wr);
+            // Note that Laputin returns newly copied duplicate version of car.
+            // This is because newer versions of file with same hash are always
+            // used to overwrite the previous path.
+            return await shouldContainFiles(laputin, [duplicateCarFile]);
         });
-    }
+    });
 
-    function moveFile(source: string, target: string): Promise<void> {
-        return new Promise<void>(function(resolve, reject) {
-            fs.rename(source, target, () => resolve());
-        });
-    }
+    describe('New directory should be skipped', () => {
+        it('Offline', async function() {
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
 
-    function delay(milliseconds: number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            setTimeout(() => resolve(), milliseconds);
+            // Initial startup and shutdown
+            laputin = await initializeLaputin(currentPath);
+            shutdownLaputin(laputin);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '/foobar');
+
+            // Detecting changes after second startup
+            await startLaputin(laputin);
+
+            return await shouldContainFiles(laputin, []);
         });
-    }
+
+        it('Online', async function() {
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+
+            laputin = await initializeLaputin(currentPath);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '/foobar');
+            await delay(1000);
+
+            return await shouldContainFiles(laputin, []);
+        });
+    });
+
+    describe('Online duplicate detection edge cases', () => {
+        it('When a file is overwritten with exact same file to exact same path, it is not detected as duplicate', async function() {
+            const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+
+            // Start monitoring after initial files have been copied
+            laputin = await initializeLaputin(currentPath);
+
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+            await waitForEvent(laputin.fileLibrary, 'found', 8000);
+
+            const duplicates = laputin.fileLibrary.getDuplicates();
+            expect(duplicates).to.eql({});
+
+            return await shouldContainFiles(laputin, [landscapeFile]);
+        });
+
+        it('When a file is renamed, it is not detected as duplicate', async function() {
+            const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
+
+            fs.mkdirSync('deploy-tests/' + currentPath + '');
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+
+            // Start monitoring after initial files have been copied
+            laputin = await initializeLaputin(currentPath);
+
+            await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
+            await waitForEvent(laputin.fileLibrary, 'found', 8000);
+
+            const duplicates = laputin.fileLibrary.getDuplicates();
+            expect(duplicates).to.eql({});
+
+            return await shouldContainFiles(laputin, [landscapeFile]);
+        });
+    });
 });
+
+function shouldContainFiles(l: Laputin, expectedFiles: File[]): request.Test {
+    return request(l.app)
+        .get('/api/files')
+        .expect(200)
+        .expect(expectedFiles);
+}
+
+function shouldContainDuplicates(l: Laputin, expectedFiles: any): request.Test {
+    return request(l.app)
+        .get('/api/duplicates')
+        .expect(200)
+        .expect(expectedFiles);
+}
+
+function waitForEvent(emitter: events.EventEmitter, eventName: string, timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const errTimeout = setTimeout(
+            () => reject(new Error('Event ' + eventName + ' was not emitted')),
+            timeoutMs);
+
+        emitter.on(eventName, () => {
+            clearTimeout(errTimeout);
+            resolve();
+        });
+    });
+}
+
+async function initializeLaputin(path: string): Promise<Laputin> {
+    const archivePath = 'deploy-tests/' + path;
+
+    if (!fs.existsSync(archivePath)) {
+        fs.mkdirSync(archivePath);
+    }
+
+    const fakeScreenshotter: any = {exists: () => {}, screenshot: () => {}, screenshotTimecode: () => {}};
+    const l = compose(archivePath, new LaputinConfiguration(1234, 'accurate'), fakeScreenshotter);
+
+    await l.library.createTables();
+
+    await startLaputin(l);
+
+    return l;
+}
+
+async function startLaputin(l: Laputin): Promise<void> {
+    l.initializeRoutes();
+    await l.loadFiles();
+    await l.startListening();
+
+    // File monitoring seems to need some time to wake up
+    await delay(100);
+}
+
+async function shutdownLaputin(l: Laputin): Promise<void> {
+    if (l) {
+        l.fileLibrary.close();
+        await l.stopListening();
+
+        await delay(100);
+    } else {
+        console.log('failed shutdown');
+    }
+}
+
+function copyFile(source: string, target: string): Promise<void> {
+    return new Promise<void>(function(resolve, reject) {
+        const rd = fs.createReadStream(source);
+        rd.on('error', reject);
+        const wr = fs.createWriteStream(target);
+        wr.on('error', reject);
+        wr.on('finish', resolve);
+        rd.pipe(wr);
+    });
+}
+
+function moveFile(source: string, target: string): Promise<void> {
+    return new Promise<void>(function(resolve, reject) {
+        fs.rename(source, target, () => resolve());
+    });
+}
+
+function delay(milliseconds: number): Promise<any> {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(), milliseconds);
+    });
+}

--- a/src/tests/monitoringtests.ts
+++ b/src/tests/monitoringtests.ts
@@ -47,7 +47,7 @@ describe('File Library', function() {
     });
 
     it('When file is copied to library path, it can be found', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 123);
+        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
 
         // Start monitoring before file is copied
         laputin = await initializeLaputin(currentPath);
@@ -58,7 +58,7 @@ describe('File Library', function() {
     });
 
     it('When file is moved without changing its content, it can be found with same hash from new path', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/automobile.jpg', [], 123);
+        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/automobile.jpg', [], 39031);
 
         fs.mkdirSync('deploy-tests/' + currentPath + '');
         await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
@@ -72,9 +72,9 @@ describe('File Library', function() {
     });
 
     it('Initial files can be found', async () => {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 123);
-        const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 123);
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 123);
+        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+        const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
+        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
 
         fs.mkdirSync('deploy-tests/' + currentPath + '');
         await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
@@ -88,9 +88,9 @@ describe('File Library', function() {
     });
 
     it('When file is deleted from library path, it can no longer be found', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 123);
-        const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 123);
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 123);
+        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+        const catsFile = new File(catFileHash, 'deploy-tests/' + currentPath + '/cats.jpg', [], 30791);
+        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
 
         fs.mkdirSync('deploy-tests/' + currentPath + '');
         await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
@@ -106,8 +106,8 @@ describe('File Library', function() {
     });
 
     it('When a duplicate file is copied to library path, it is detected as duplicate', async function() {
-        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 123);
-        const duplicateCarFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car-duplicate.jpg', [], 123);
+        const carFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car.jpg', [], 39031);
+        const duplicateCarFile = new File(carFileHash, 'deploy-tests/' + currentPath + '/car-duplicate.jpg', [], 39031);
 
         fs.mkdirSync('deploy-tests/' + currentPath + '');
         await copyFile('tests/test-content/car.jpg', 'deploy-tests/' + currentPath + '/car.jpg');
@@ -131,7 +131,7 @@ describe('File Library', function() {
     });
 
     it('When a file is overwritten with exact same file to exact same path, it is not detected as duplicate', async function() {
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 123);
+        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
 
         fs.mkdirSync('deploy-tests/' + currentPath + '');
         await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
@@ -149,7 +149,7 @@ describe('File Library', function() {
     });
 
     it('When a file is renamed, it is not detected as duplicate', async function() {
-        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 123);
+        const landscapeFile = new File(landscapeFileHash, 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg', [], 73221);
 
         fs.mkdirSync('deploy-tests/' + currentPath + '');
         await copyFile('tests/test-content/jyvasjarvi.jpg', 'deploy-tests/' + currentPath + '/jyvasjarvi.jpg');
@@ -211,7 +211,8 @@ describe('File Library', function() {
             fs.mkdirSync(archivePath);
         }
 
-        const l = compose(archivePath, new LaputinConfiguration(1234, 'accurate'));
+        const fakeScreenshotter: any = {exists: () => {}, screenshot: () => {}, screenshotTimecode: () => {}};
+        const l = compose(archivePath, new LaputinConfiguration(1234, 'accurate'), fakeScreenshotter);
         l.initializeRoutes();
         await l.library.createTables();
         await l.loadFiles();

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -21,10 +21,6 @@
     ],
     "interface-over-type-literal": true,
     "label-position": true,
-    "max-line-length": [
-      true,
-      140
-    ],
     "member-access": false,
     "member-ordering": [
       true,


### PR DESCRIPTION
This removes deactivating all files during startup and re-hashing them even though they would not have changed at all. For a large library this reduces startup time from even 10 minutes down to less than 10 seconds.