### PR TITLE
Supports proxy files

### DIFF
--- a/src/client/src/app/laputin.service.ts
+++ b/src/client/src/app/laputin.service.ts
@@ -175,6 +175,12 @@ export class LaputinService {
         return this.addTags(file, [tag]);
     }
 
+    public proxyExists(file: File): Observable<boolean> {
+        return this._http
+            .get(this._baseUrl + '/proxyExists/' + file.hash)
+            .map(res => res.json());
+    }
+
     public deleteTagFileAssoc(file: File, tag: Tag): Observable<Response> {
         return this._http.delete(this._baseUrl + '/files/' + file.hash + '/tags/' + tag.id);
     }

--- a/src/client/src/app/video-player/video-player.component.html
+++ b/src/client/src/app/video-player/video-player.component.html
@@ -14,7 +14,7 @@
             </div>
 
             <div [ngClass]="{ 'hidden': !playbackHasBeenStarted }" class="video-container">
-                <video src="/media/{{file.escapedUrl()}}" #player></video>
+                <video src="{{videoSource}}" #player></video>
             </div>
         </div>
 

--- a/src/client/src/app/video-player/video-player.component.ts
+++ b/src/client/src/app/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter, Injectable, ViewChild, ElementRef, AfterViewInit, OnDestroy} from '@angular/core';
+import {Component, Input, Output, EventEmitter, Injectable, ViewChild, ElementRef, AfterViewInit, OnDestroy, OnInit} from '@angular/core';
 import * as _ from 'lodash';
 import * as moment from 'moment';
 import { Observable } from 'rxjs/Rx';
@@ -18,7 +18,7 @@ import { MatSliderChange } from '@angular/material';
     templateUrl: './video-player.component.html'
 })
 @Injectable()
-export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
+export class VideoPlayerComponent implements OnInit, AfterViewInit, OnDestroy {
     public playbackHasBeenStarted: boolean;
     public playing: boolean;
     public random: boolean;
@@ -48,12 +48,24 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     public sliderMax = 1000000;
     public sliderValue: number;
 
+    public videoSource: string;
+
     @Output()
     public fileChange: EventEmitter<FileChange> = new EventEmitter<FileChange>();
     @Output()
     public fileClosed: EventEmitter<void> = new EventEmitter<void>();
 
     constructor(private _service: LaputinService, private _playerService: PlayerService) {
+    }
+
+    public ngOnInit(): void {
+        this._service.proxyExists(this.file).subscribe(proxyExists => {
+            if (proxyExists) {
+                this.videoSource = `/proxies/${this.file.hash}.mp4`;
+            } else {
+                this.videoSource = `/media/${this.file.escapedUrl()}`;
+            }
+        });
     }
 
     public ngAfterViewInit(): void {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -18,7 +18,14 @@ export function compose(libraryPath: string, configuration: LaputinConfiguration
 
     const opener = new VLCOpener(libraryPath);
 
-    return new Laputin(libraryPath, library, fileLibrary, opener, configuration.port);
+    return new Laputin(
+        libraryPath,
+        library,
+        fileLibrary,
+        opener,
+        configuration.port,
+        configuration.proxyDirectory
+    );
 }
 
 export function composeForTests(
@@ -33,7 +40,14 @@ export function composeForTests(
 
     const opener = new VLCOpener(libraryPath);
 
-    return new Laputin(libraryPath, library, fileLibrary, opener, configuration.port);
+    return new Laputin(
+        libraryPath,
+        library,
+        fileLibrary,
+        opener,
+        configuration.port,
+        configuration.proxyDirectory
+    );
 }
 
 function composeHasher(configuration: LaputinConfiguration): IHasher {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import { Screenshotter } from './screenshotter';
     const configFilePath = path.join(options.libraryPath, '.laputin.json');
     const configuration: LaputinConfiguration = (fs.existsSync(configFilePath))
         ? JSON.parse(fs.readFileSync(configFilePath, 'utf8'))
-        : new LaputinConfiguration(3200, 'accurate');
+        : new LaputinConfiguration(3200, 'accurate', null);
 
     const laputin = compose(options.libraryPath, configuration);
 

--- a/src/laputinconfiguration.ts
+++ b/src/laputinconfiguration.ts
@@ -1,4 +1,4 @@
 export class LaputinConfiguration {
-    constructor(public port: number, public identification: string) {
+    constructor(public port: number, public identification: string, public proxyDirectory: string) {
     }
 }

--- a/src/tests/apitests.ts
+++ b/src/tests/apitests.ts
@@ -265,7 +265,7 @@ describe('Laputin API', function () {
         fs.mkdirSync(archivePath);
 
         const fakeScreenshotter: any = {exists: () => {}, screenshot: () => {}, screenshotTimecode: () => {}};
-        const l = composeForTests(archivePath, new LaputinConfiguration(1234, 'accurate'), fakeScreenshotter);
+        const l = composeForTests(archivePath, new LaputinConfiguration(1234, 'accurate', null), fakeScreenshotter);
         l.initializeRoutes();
 
         await l.library.createTables();

--- a/src/tests/monitoringtests.ts
+++ b/src/tests/monitoringtests.ts
@@ -318,7 +318,7 @@ async function initializeLaputin(path: string): Promise<Laputin> {
     }
 
     const fakeScreenshotter: any = {exists: () => {}, screenshot: () => {}, screenshotTimecode: () => {}};
-    const l = composeForTests(archivePath, new LaputinConfiguration(1234, 'accurate'), fakeScreenshotter);
+    const l = composeForTests(archivePath, new LaputinConfiguration(1234, 'accurate', null), fakeScreenshotter);
 
     await l.library.createTables();
 


### PR DESCRIPTION
Video player uses proxy file if one is available. If not, video player defaults to original file.

Proxy files help with browser compatibility issues. For example Chrome does not support H.265, Edge does not support 10-bit H.265 and none of the browsers support Matroska containers.

User can configure proxy directory via .laputin.json.

For now user must manually create proxy files by adding a file with name [file hash].mp4 to proxy directory.

Closes #51.