### PR TITLE
Fix: file.path should not have unique constraint

### DIFF
--- a/oclif/prisma/schema.prisma
+++ b/oclif/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 model File {
   id               Int                @id @default(autoincrement())
   hash             String             @unique()
-  path             String             @unique()
+  path             String
   active           Int
   size             BigInt
   metadata         Json


### PR DESCRIPTION
Inactive older files may already be present in database when a better quality newer file appears in same path. New file should be able to exist.